### PR TITLE
fix(api): restrict paperless delete proxy to duplicate members

### DIFF
--- a/packages/web/src/routes/api/v1/paperless/documents/[paperlessId]/+server.ts
+++ b/packages/web/src/routes/api/v1/paperless/documents/[paperlessId]/+server.ts
@@ -1,4 +1,6 @@
 import { apiSuccess, apiError, ErrorCode } from '$lib/server/api';
+import { document, duplicateMember } from '@paperless-dedupe/core';
+import { eq } from 'drizzle-orm';
 import type { RequestHandler } from './$types';
 
 function buildAuthHeaders(config: App.Locals['config']): Record<string, string> {
@@ -18,6 +20,20 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
   const paperlessId = Number(params.paperlessId);
   if (isNaN(paperlessId) || paperlessId <= 0) {
     return apiError(ErrorCode.BAD_REQUEST, 'Invalid paperless document ID');
+  }
+
+  const duplicateMemberMatch = locals.db
+    .select({ id: duplicateMember.id })
+    .from(duplicateMember)
+    .innerJoin(document, eq(duplicateMember.documentId, document.id))
+    .where(eq(document.paperlessId, paperlessId))
+    .get();
+
+  if (!duplicateMemberMatch) {
+    return apiError(
+      ErrorCode.NOT_FOUND,
+      'Document is not part of a duplicate group member and cannot be deleted here',
+    );
   }
 
   const config = locals.config;


### PR DESCRIPTION
### Motivation

- A new unauthenticated `DELETE /api/v1/paperless/documents/[paperlessId]` handler previously forwarded deletes for any numeric ID to the configured Paperless instance, allowing arbitrary document deletion via the proxy. 
- The change scopes deletions so the endpoint can only delete documents that are tracked as duplicate-group members, preventing arbitrary ID-based deletes.

### Description

- Added imports for `document`, `duplicateMember` and `eq` and inserted a local database membership check in `packages/web/src/routes/api/v1/paperless/documents/[paperlessId]/+server.ts` to verify the `paperlessId` is present as a duplicate-member before proxying the delete. 
- If the `paperlessId` is not found as a duplicate member the handler now returns `NOT_FOUND` via `apiError`, and it only forwards the DELETE upstream for verified duplicate members. 
- Preserved the existing upstream delete flow, authentication header construction, and error handling for valid requests.

### Testing

- Ran `pnpm --filter @paperless-dedupe/web check`, which runs `svelte-check`, and it completed with `svelte-check found 0 errors and 0 warnings` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ed052438b483248c7607d231dece50)