### PR TITLE
Require authorization for Paperless preview/thumb proxy endpoints

### DIFF
--- a/packages/web/src/lib/server/paperless-auth.ts
+++ b/packages/web/src/lib/server/paperless-auth.ts
@@ -1,0 +1,39 @@
+import { apiError, ErrorCode } from '$lib/server/api';
+
+function getPaperlessAuthorization(config: App.Locals['config']): string | null {
+  if (config.PAPERLESS_API_TOKEN) {
+    return `Token ${config.PAPERLESS_API_TOKEN}`;
+  }
+
+  if (config.PAPERLESS_USERNAME && config.PAPERLESS_PASSWORD) {
+    const encoded = Buffer.from(
+      `${config.PAPERLESS_USERNAME}:${config.PAPERLESS_PASSWORD}`,
+    ).toString('base64');
+    return `Basic ${encoded}`;
+  }
+
+  return null;
+}
+
+export function buildPaperlessAuthHeaders(config: App.Locals['config']): Record<string, string> {
+  const authorization = getPaperlessAuthorization(config);
+  if (!authorization) {
+    return {};
+  }
+
+  return { Authorization: authorization };
+}
+
+export function requirePaperlessAuthorization(
+  request: Request,
+  config: App.Locals['config'],
+) {
+  const expected = getPaperlessAuthorization(config);
+  const provided = request.headers.get('authorization');
+
+  if (!expected || !provided || provided.trim() !== expected) {
+    return apiError(ErrorCode.UNAUTHORIZED, 'Unauthorized');
+  }
+
+  return null;
+}

--- a/packages/web/src/routes/api/v1/paperless/documents/[paperlessId]/preview/+server.ts
+++ b/packages/web/src/routes/api/v1/paperless/documents/[paperlessId]/preview/+server.ts
@@ -1,29 +1,24 @@
 import { apiError, ErrorCode } from '$lib/server/api';
+import { buildPaperlessAuthHeaders, requirePaperlessAuthorization } from '$lib/server/paperless-auth';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ params, locals }) => {
+export const GET: RequestHandler = async ({ params, locals, request }) => {
   const paperlessId = Number(params.paperlessId);
   if (isNaN(paperlessId) || paperlessId <= 0) {
     return apiError(ErrorCode.BAD_REQUEST, 'Invalid paperless document ID');
   }
 
   const config = locals.config;
+  const unauthorized = requirePaperlessAuthorization(request, config);
+  if (unauthorized) {
+    return unauthorized;
+  }
   const baseUrl = config.PAPERLESS_URL.replace(/\/+$/, '');
   const url = `${baseUrl}/api/documents/${paperlessId}/preview/`;
 
-  const headers: Record<string, string> = {};
-  if (config.PAPERLESS_API_TOKEN) {
-    headers['Authorization'] = `Token ${config.PAPERLESS_API_TOKEN}`;
-  } else if (config.PAPERLESS_USERNAME && config.PAPERLESS_PASSWORD) {
-    const encoded = Buffer.from(
-      `${config.PAPERLESS_USERNAME}:${config.PAPERLESS_PASSWORD}`,
-    ).toString('base64');
-    headers['Authorization'] = `Basic ${encoded}`;
-  }
-
   try {
     const upstream = await fetch(url, {
-      headers,
+      headers: buildPaperlessAuthHeaders(config),
       signal: AbortSignal.timeout(30000),
     });
 

--- a/packages/web/src/routes/api/v1/paperless/documents/[paperlessId]/thumb/+server.ts
+++ b/packages/web/src/routes/api/v1/paperless/documents/[paperlessId]/thumb/+server.ts
@@ -1,29 +1,24 @@
 import { apiError, ErrorCode } from '$lib/server/api';
+import { buildPaperlessAuthHeaders, requirePaperlessAuthorization } from '$lib/server/paperless-auth';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ params, locals }) => {
+export const GET: RequestHandler = async ({ params, locals, request }) => {
   const paperlessId = Number(params.paperlessId);
   if (isNaN(paperlessId) || paperlessId <= 0) {
     return apiError(ErrorCode.BAD_REQUEST, 'Invalid paperless document ID');
   }
 
   const config = locals.config;
+  const unauthorized = requirePaperlessAuthorization(request, config);
+  if (unauthorized) {
+    return unauthorized;
+  }
   const baseUrl = config.PAPERLESS_URL.replace(/\/+$/, '');
   const url = `${baseUrl}/api/documents/${paperlessId}/thumb/`;
 
-  const headers: Record<string, string> = {};
-  if (config.PAPERLESS_API_TOKEN) {
-    headers['Authorization'] = `Token ${config.PAPERLESS_API_TOKEN}`;
-  } else if (config.PAPERLESS_USERNAME && config.PAPERLESS_PASSWORD) {
-    const encoded = Buffer.from(
-      `${config.PAPERLESS_USERNAME}:${config.PAPERLESS_PASSWORD}`,
-    ).toString('base64');
-    headers['Authorization'] = `Basic ${encoded}`;
-  }
-
   try {
     const upstream = await fetch(url, {
-      headers,
+      headers: buildPaperlessAuthHeaders(config),
       signal: AbortSignal.timeout(15000),
     });
 


### PR DESCRIPTION
### Motivation
- The preview and thumbnail proxy endpoints were using server-side Paperless credentials to fetch content and returning it to callers without any authentication or authorization, exposing privileged Paperless data to unauthenticated clients.

### Description
- Add a shared helper `packages/web/src/lib/server/paperless-auth.ts` that builds outbound Paperless `Authorization` headers and validates inbound `Authorization` headers against the configured Paperless credentials.
- Gate `GET /api/v1/paperless/documents/[paperlessId]/preview` by calling `requirePaperlessAuthorization` and use `buildPaperlessAuthHeaders` for the upstream request.
- Gate `GET /api/v1/paperless/documents/[paperlessId]/thumb` by calling `requirePaperlessAuthorization` and use `buildPaperlessAuthHeaders` for the upstream request.
- Preserve existing upstream behavior and timeouts while returning `UNAUTHORIZED` when the inbound `Authorization` header is missing or incorrect.

### Testing
- Ran static checks with `pnpm --filter @paperless-dedupe/web check`, which completed with no errors.
- Ran linting on the changed files with `pnpm exec eslint` for the new helper and updated endpoints, which succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ed12f522b88324ac5e6e1a85686f15)