### PR TITLE
Redact sensitive config fields from config API responses

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -220,7 +220,7 @@ export {
   StatusTransitionError,
   PrimaryMemberError,
 } from './queries/duplicates.js';
-export { getConfig, setConfig, setConfigBatch } from './queries/config.js';
+export { getConfig, redactSensitiveConfig, setConfig, setConfigBatch } from './queries/config.js';
 
 // Telemetry
 export {

--- a/packages/core/src/queries/__tests__/config.test.ts
+++ b/packages/core/src/queries/__tests__/config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { createDatabaseWithHandle } from '../../db/client.js';
 import { migrateDatabase } from '../../db/migrate.js';
 import type { AppDatabase } from '../../db/client.js';
-import { getConfig, setConfig, setConfigBatch } from '../config.js';
+import { getConfig, redactSensitiveConfig, setConfig, setConfigBatch } from '../config.js';
 
 // Migration seeds schema_ddl_hash and schema_ddl_snapshot into app_config.
 // These tests account for those pre-existing rows.
@@ -122,5 +122,23 @@ describe('setConfigBatch', () => {
     expect(config.c).toBe('3');
     expect(config.d).toBe('4');
     expect(Object.keys(config).length).toBe(baseKeyCount + 4);
+  });
+});
+
+describe('redactSensitiveConfig', () => {
+  it('removes sensitive paperless credential keys', () => {
+    const redacted = redactSensitiveConfig({
+      'paperless.url': 'http://localhost:8000',
+      'paperless.apiToken': 'token-123',
+      'paperless.username': 'alice',
+      'paperless.password': 'super-secret',
+      theme: 'dark',
+    });
+
+    expect(redacted['paperless.url']).toBe('http://localhost:8000');
+    expect(redacted.theme).toBe('dark');
+    expect(redacted['paperless.apiToken']).toBeUndefined();
+    expect(redacted['paperless.username']).toBeUndefined();
+    expect(redacted['paperless.password']).toBeUndefined();
   });
 });

--- a/packages/core/src/queries/config.ts
+++ b/packages/core/src/queries/config.ts
@@ -1,11 +1,26 @@
 import type { AppDatabase } from '../db/client.js';
 import { appConfig } from '../schema/sqlite/app.js';
 
+const SENSITIVE_CONFIG_KEYS = new Set([
+  'paperless.apiToken',
+  'paperless.username',
+  'paperless.password',
+]);
+
 export function getConfig(db: AppDatabase): Record<string, string> {
   const rows = db.select().from(appConfig).all();
   const result: Record<string, string> = {};
   for (const row of rows) {
     result[row.key] = row.value;
+  }
+  return result;
+}
+
+export function redactSensitiveConfig(config: Record<string, string>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(config)) {
+    if (SENSITIVE_CONFIG_KEYS.has(key)) continue;
+    result[key] = value;
   }
   return result;
 }

--- a/packages/web/src/routes/api/v1/config/+server.ts
+++ b/packages/web/src/routes/api/v1/config/+server.ts
@@ -1,5 +1,5 @@
 import { apiSuccess, apiError, ErrorCode } from '$lib/server/api';
-import { getConfig, setConfig, setConfigBatch } from '@paperless-dedupe/core';
+import { getConfig, redactSensitiveConfig, setConfig, setConfigBatch } from '@paperless-dedupe/core';
 import { z } from 'zod';
 import type { RequestHandler } from './$types';
 
@@ -14,7 +14,7 @@ const batchConfigSchema = z.object({
 
 export const GET: RequestHandler = async ({ locals }) => {
   const config = getConfig(locals.db);
-  return apiSuccess(config);
+  return apiSuccess(redactSensitiveConfig(config));
 };
 
 export const PUT: RequestHandler = async ({ request, locals }) => {
@@ -30,14 +30,14 @@ export const PUT: RequestHandler = async ({ request, locals }) => {
   if (singleResult.success) {
     setConfig(locals.db, singleResult.data.key, singleResult.data.value);
     const config = getConfig(locals.db);
-    return apiSuccess(config);
+    return apiSuccess(redactSensitiveConfig(config));
   }
 
   const batchResult = batchConfigSchema.safeParse(body);
   if (batchResult.success) {
     setConfigBatch(locals.db, batchResult.data.settings);
     const config = getConfig(locals.db);
-    return apiSuccess(config);
+    return apiSuccess(redactSensitiveConfig(config));
   }
 
   return apiError(


### PR DESCRIPTION
### Motivation
- The config API returned the entire `app_config` table (including `paperless.apiToken`, `paperless.username`, and `paperless.password`) to any client via `GET /api/v1/config`, exposing credentials to unauthenticated callers.

### Description
- Add `SENSITIVE_CONFIG_KEYS` and `redactSensitiveConfig` to `packages/core/src/queries/config.ts` to strip credential keys from config objects. 
- Export `redactSensitiveConfig` from core's public index so routes can use it. 
- Update `GET` and `PUT` handlers in `packages/web/src/routes/api/v1/config/+server.ts` to return `redactSensitiveConfig(getConfig(...))` instead of the raw config. 
- Add a unit test in `packages/core/src/queries/__tests__/config.test.ts` to assert sensitive keys are removed while non-sensitive keys remain.

### Testing
- Ran `pnpm --filter @paperless-dedupe/core test -- packages/core/src/queries/__tests__/config.test.ts` and observed the core test suite complete successfully. 
- Test summary: 49 test files executed; 721 tests passed and 9 skipped (all tests in the run succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ed14e7a0c883248bd176cf170258a7)