### PR TITLE
chore(renovate): group Vercel AI SDK packages into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     {
       "description": "Bundle the Vercel AI SDK packages into a single PR. @ai-sdk/openai major versions are coupled to the ai package's accepted model specificationVersion (e.g. @ai-sdk/openai v4 emits a v4 model spec that only ai v7 accepts), so they must be upgraded together or CI fails to type-check.",
       "groupName": "ai sdk",
-      "matchPackageNames": ["ai", "@ai-sdk/openai", "/^@ai-sdk\\//"]
+      "matchPackageNames": ["ai", "@ai-sdk/**"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,10 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Bundle the Vercel AI SDK packages into a single PR. @ai-sdk/openai major versions are coupled to the ai package's accepted model specificationVersion (e.g. @ai-sdk/openai v4 emits a v4 model spec that only ai v7 accepts), so they must be upgraded together or CI fails to type-check.",
+      "groupName": "ai sdk",
+      "matchPackageNames": ["ai", "@ai-sdk/openai", "/^@ai-sdk\\//"]
+    }
+  ]
 }


### PR DESCRIPTION
## Why

`@ai-sdk/openai` major versions are coupled to the `ai` package's accepted model `specificationVersion`. Concretely, `@ai-sdk/openai` v4 emits `LanguageModelV4`/`EmbeddingModelV4` (`specificationVersion: "v4"`), which `ai` v6 rejects and only `ai` v7 accepts.

Renovate previously split these into two PRs (#370 `@ai-sdk/openai` v4 and #371 `ai` v7). The openai-v4 PR could never pass CI on its own — it failed `tsc` with `Type 'LanguageModelV4' is not assignable to type 'LanguageModel'` until `ai` v7 was also present.

## What

Adds a `packageRules` group so `ai` and every `@ai-sdk/*` package are always bundled into a single Renovate PR, upgrading together.

This complements the manual fix on #370, where `ai` v7 was bundled into the `@ai-sdk/openai` v4 branch (superseding #371).

🤖 Generated with [Claude Code](https://claude.com/claude-code)