### PR TITLE
ci: adopt shared reusable security workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,12 @@
+name: actionlint
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ['**']
+permissions: {}
+jobs:
+  actionlint:
+    permissions:
+      contents: read
+    uses: rknightion/.github/.github/workflows/actionlint.yml@main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,19 @@
+name: CodeQL
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '7 3 * * 1'
+permissions: {}
+jobs:
+  codeql:
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    uses: rknightion/.github/.github/workflows/codeql.yml@main
+    with:
+      languages: '[{"language":"javascript-typescript","build-mode":"none"},{"language":"actions","build-mode":"none"}]'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,11 @@
+name: Dependency review
+on:
+  pull_request:
+    branches: [main]
+permissions: {}
+jobs:
+  dependency-review:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: rknightion/.github/.github/workflows/dependency-review.yml@main

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -1,58 +1,14 @@
 name: Docker Security
-
-# hadolint (Dockerfile lint) + Trivy (filesystem vuln/misconfig/secret scan), results uploaded to the
-# GitHub Security tab as SARIF. Runs on main pushes + weekly so newly disclosed CVEs surface without a
-# code change. Non-gating (not a required check). pull_request is intentionally omitted: SARIF upload
-# needs security-events: write, which fork PRs don't get.
 on:
   push:
     branches: [main]
   schedule:
-    - cron: '30 5 * * 1'
+    - cron: '17 5 * * 1'
   workflow_dispatch:
-
-permissions:
-  contents: read
-
+permissions: {}
 jobs:
-  hadolint:
-    name: hadolint
-    runs-on: ubuntu-latest
+  docker-security:
     permissions:
       contents: read
       security-events: write
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
-        with:
-          dockerfile: Dockerfile
-          format: sarif
-          output-file: hadolint.sarif
-          no-fail: true
-      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        with:
-          sarif_file: hadolint.sarif
-          category: hadolint
-
-  trivy:
-    name: trivy
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          scan-type: fs
-          scanners: vuln,misconfig,secret
-          format: sarif
-          output: trivy.sarif
-      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        with:
-          sarif_file: trivy.sarif
-          category: trivy-fs
+    uses: rknightion/.github/.github/workflows/docker-security.yml@main

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,14 @@
+name: zizmor
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ['**']
+permissions: {}
+jobs:
+  zizmor:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    uses: rknightion/.github/.github/workflows/zizmor.yml@main


### PR DESCRIPTION
Adopts the fleet-wide reusable security/CI workflows from rknightion/.github (CodeQL security-extended + actions language, zizmor, actionlint, dependency-review, docker-security). Opened as a PR (not pushed to main) because another agent is working on this repo.