### PR TITLE
Add cloud environment setup script and Backlog task

### DIFF
--- a/backlog/tasks/pnd-0002 - Add-cloud-environment-setup-script.md
+++ b/backlog/tasks/pnd-0002 - Add-cloud-environment-setup-script.md
@@ -1,0 +1,62 @@
+---
+id: PND-0002
+title: Add cloud environment setup script
+status: Done
+assignee: []
+created_date: '2026-08-16 11:37'
+updated_date: '2026-08-16 11:46'
+labels: []
+dependencies: []
+references:
+  - 'https://learn.chatgpt.com/docs/environments/cloud-environment#manual-setup'
+  - 'https://code.claude.com/docs/en/cloud-environments#setup-scripts'
+modified_files:
+  - scripts/cloud-environment-setup.sh
+type: chore
+ordinal: 2000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Provide a repository-owned manual setup script for Codex Cloud Tasks and Claude Code cloud environments. It must provision the Node/pnpm toolchain, project dependencies, Backlog.md CLI, and browser/testing dependencies needed by future agents.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 scripts/cloud-environment-setup.sh begins with a warning that non-cloud agents must not run it
+- [x] #2 The script installs and verifies Node.js 24, the lockfile-pinned pnpm version, Backlog.md CLI 1.50.1, project dependencies, and Playwright Chromium dependencies
+- [x] #3 The script is safe to rerun and compatible with Codex and Claude Code Ubuntu cloud environments
+- [x] #4 Shell syntax, lint, type-check, and the full build pass; any unrelated baseline failures are documented
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 pnpm lint && pnpm format --write && pnpm check && pnpm test
+- [x] #2 pnpm build (core then web, in dependency order)
+- [ ] #3 pnpm test:e2e (only if packages/web behaviour changed)
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a fail-fast, idempotent Bash script that detects the repository root and provisions Node.js 24 across the Codex and Claude Ubuntu images.
+
+2. Activate the lockfile-declared pnpm version, install Backlog.md and frozen project dependencies, and install Playwright Chromium system/browser dependencies.
+
+3. Validate shell syntax, formatting, lint, type-check, unit tests, and the full build; then finalize and commit the task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the cloud-only setup script with a portable Node.js 24 installer, pinned global pnpm and Backlog.md CLIs, frozen dependency installation, and Playwright Chromium plus Ubuntu dependency installation.
+
+Validation found two unrelated repository baseline issues: Prettier reports five existing/generated Markdown or YAML files, and the existing bounded AI inbox detail test consistently exceeds its 5-second timeout. Lint, type-check, build, script syntax, archive discovery, and diff checks pass.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added an executable, idempotent cloud-only provisioning script for Codex and Claude Code that installs Node.js 24, pnpm 11.18.0, Backlog.md 1.50.1, frozen workspace dependencies, and Playwright Chromium dependencies. Verified its contract and Bash syntax, plus repository lint, type-check, and build; documented unrelated baseline format and unit-test failures.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/scripts/cloud-environment-setup.sh
+++ b/scripts/cloud-environment-setup.sh
@@ -83,7 +83,17 @@ log 'Installing repository dependencies from the frozen lockfile'
 pnpm install --frozen-lockfile
 
 log 'Installing Chromium and its Ubuntu system dependencies for Playwright tests'
-pnpm --filter @paperless-dedupe/web exec playwright install --with-deps chromium
+for attempt in 1 2 3; do
+  if [[ ${attempt} -gt 1 ]]; then
+    log "Retrying Playwright install (attempt ${attempt}/3)"
+  fi
+  if timeout 300 pnpm --filter @paperless-dedupe/web exec playwright install --with-deps chromium; then
+    break
+  elif [[ ${attempt} -eq 3 ]]; then
+    log "Playwright install failed after 3 attempts"
+    exit 1
+  fi
+done
 
 log 'Verifying the cloud task toolchain'
 node --version

--- a/scripts/cloud-environment-setup.sh
+++ b/scripts/cloud-environment-setup.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# CLOUD AGENTS ONLY: local agents must not execute this environment-provisioning script.
+
+set -Eeuo pipefail
+
+readonly NODE_MAJOR=24
+readonly PNPM_VERSION=11.18.0
+readonly BACKLOG_VERSION=1.50.1
+
+log() {
+  printf '\n==> %s\n' "$*"
+}
+
+as_root() {
+  if [[ ${EUID} -eq 0 ]]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    printf 'This setup needs root access to install system tools.\n' >&2
+    return 1
+  fi
+}
+
+install_node() {
+  if command -v node >/dev/null 2>&1 && [[ $(node --version) == "v${NODE_MAJOR}."* ]]; then
+    log "Node.js $(node --version) is already available"
+    return
+  fi
+
+  local architecture node_arch temporary_directory node_archive
+  architecture=$(uname -m)
+  case "${architecture}" in
+    x86_64) node_arch=x64 ;;
+    aarch64 | arm64) node_arch=arm64 ;;
+    *)
+      printf 'Unsupported architecture for Node.js: %s\n' "${architecture}" >&2
+      return 1
+      ;;
+  esac
+
+  temporary_directory=$(mktemp -d)
+  trap 'rm -rf "${temporary_directory}"' RETURN
+
+  log "Installing the latest Node.js ${NODE_MAJOR}.x release"
+  curl --fail --location --retry 3 --silent --show-error \
+    "https://nodejs.org/dist/latest-v${NODE_MAJOR}.x/" -o "${temporary_directory}/index.html"
+  node_archive=$(sed -n "s#.*>\(node-v${NODE_MAJOR}[^<]*-linux-${node_arch}\\.tar\\.xz\)</a>.*#\1#p" \
+    "${temporary_directory}/index.html" | head -n 1)
+  if [[ -z ${node_archive} ]]; then
+    printf 'Could not determine the latest Node.js %s archive.\n' "${NODE_MAJOR}" >&2
+    return 1
+  fi
+
+  curl --fail --location --retry 3 --silent --show-error \
+    "https://nodejs.org/dist/latest-v${NODE_MAJOR}.x/${node_archive}" \
+    -o "${temporary_directory}/${node_archive}"
+  curl --fail --location --retry 3 --silent --show-error \
+    "https://nodejs.org/dist/latest-v${NODE_MAJOR}.x/SHASUMS256.txt" \
+    -o "${temporary_directory}/SHASUMS256.txt"
+  (
+    cd "${temporary_directory}"
+    grep " ${node_archive}$" SHASUMS256.txt | sha256sum --check --strict -
+  )
+
+  as_root tar --extract --xz --file "${temporary_directory}/${node_archive}" \
+    --directory /usr/local --strip-components=1
+  hash -r
+}
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+cd "${repo_root}"
+
+install_node
+
+log "Installing pnpm ${PNPM_VERSION} and Backlog.md ${BACKLOG_VERSION}"
+as_root env PATH="${PATH}" npm install --global \
+  "pnpm@${PNPM_VERSION}" \
+  "backlog.md@${BACKLOG_VERSION}"
+hash -r
+
+log 'Installing repository dependencies from the frozen lockfile'
+pnpm install --frozen-lockfile
+
+log 'Installing Chromium and its Ubuntu system dependencies for Playwright tests'
+pnpm --filter @paperless-dedupe/web exec playwright install --with-deps chromium
+
+log 'Verifying the cloud task toolchain'
+node --version
+pnpm --version
+backlog --version
+pnpm --filter @paperless-dedupe/web exec playwright --version
+
+log 'Cloud environment setup complete'


### PR DESCRIPTION
### Motivation

- Provide a repository-owned, manual cloud environment setup script so Codex Cloud Tasks and Claude Code cloud sessions can provision a consistent runtime instead of relying on automatic installs.
- Ensure cloud agents have `backlog.md` available and the toolchain (Node 24, lockfile pnpm, Playwright) needed to run lint, type-check, tests and E2E validation.

### Description

- Add an executable cloud-only provisioning script at `scripts/cloud-environment-setup.sh` that begins with a warning that local agents must not run it and is written to be idempotent and fail-fast where appropriate.
- The script installs Node.js 24 (portable archive installer with checksum verification for x86_64 and arm64), installs pinned `pnpm` and `backlog.md` globals, runs `pnpm install --frozen-lockfile`, and installs Playwright Chromium plus its Ubuntu dependencies via `playwright install --with-deps chromium`.
- The script supports root or `sudo` installs, adjusts `PATH` usage for in-script verification, and prints verification of `node`, `pnpm`, `backlog`, and `playwright` versions at the end.
- Add a Backlog task file `backlog/tasks/PND-0002 - Add-cloud-environment-setup-script.md` documenting the change, acceptance criteria, implementation notes, and final summary.

### Testing

- Ran `bash -n scripts/cloud-environment-setup.sh` to verify shell syntax and it passed.
- Installed dependencies with `pnpm install --frozen-lockfile` and the install completed successfully in this environment.
- Ran `pnpm lint` and `pnpm check` and they succeeded with no blocking lint/type errors reported.
- Ran `pnpm format` (Prettier) which reported existing formatting warnings in five Markdown/YAML files; these are pre-existing repository baseline issues and were documented.
- Ran unit tests via `pnpm test` (Vitest): the suite mostly passed, but one existing test (`returns a bounded safe inbox detail without raw model or exception payloads`) timed out and remains a baseline failing test; other tests ran successfully (majority passed, several skipped where configured).
- Ran `pnpm build` (core then web) and the build completed successfully, including client and server SvelteKit outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81a02a0718832bb4909238d535fc2d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cloud-environment setup script for supported Ubuntu x86_64 and ARM64 systems.
  * Automatically installs Node.js 24, pinned package-management and project tooling versions, project dependencies, and Playwright Chromium requirements.
  * Verifies downloaded components and the completed toolchain.

* **Documentation**
  * Added task documentation covering the setup script’s scope, acceptance criteria, validation results, and known baseline issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->